### PR TITLE
Add support for video recording

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
           key: v1-npmcache-{{ checksum "wp-e2e-tests/.nvmrc" }}-{{ checksum "wp-e2e-tests/package-lock.json" }}
           paths:
             - "~/.npm"
+      - run: sudo apt install ffmpeg
       - run: sudo chmod +x wp-e2e-tests/node_modules/.bin/magellan
       - run: cd wp-e2e-tests && npm run decryptconfig && ./run.sh -R -j $RUN_ARGS
       - store_test_results:


### PR DESCRIPTION
This is needed to support videos of test runs. An environment variable will be added to CircleCI to turn on the recording, but this is needed as a dependency